### PR TITLE
Support reading template files within jar files.

### DIFF
--- a/watertemplate-engine/src/main/java/org/watertemplate/interpreter/WaterInterpreter.java
+++ b/watertemplate-engine/src/main/java/org/watertemplate/interpreter/WaterInterpreter.java
@@ -8,7 +8,7 @@ import org.watertemplate.interpreter.parser.Parser;
 import org.watertemplate.interpreter.parser.Token;
 
 import java.io.File;
-import java.net.URL;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.BiFunction;
@@ -29,23 +29,23 @@ public abstract class WaterInterpreter {
         return new Parser().parse(tokens);
     }
 
-    List<Token> lex(final File templateFile) {
-        return new Lexer().lex(templateFile);
+    List<Token> lex(final InputStream stream) {
+        return new Lexer().lex(stream);
     }
 
-    File templateFileWith(final Locale locale) {
+    InputStream templateFileWith(final Locale locale) {
         final String templateFileURI = "templates" + File.separator + locale + File.separator + templateFilePath;
-        final URL url = getClass().getClassLoader().getResource(templateFileURI);
+        InputStream stream = getClass().getClassLoader().getResourceAsStream(templateFileURI);
 
-        if (url != null) {
-            return new File(url.getFile());
+        if (stream == null && !locale.equals(defaultLocale)) {
+            stream = templateFileWith(defaultLocale);
         }
 
-        if (!locale.equals(defaultLocale)) {
-            return templateFileWith(defaultLocale);
+        if (stream == null) {
+            throw new TemplateFileNotFoundException(templateFilePath);
         }
 
-        throw new TemplateFileNotFoundException(templateFilePath);
+        return stream;
     }
 
     //

--- a/watertemplate-engine/src/main/java/org/watertemplate/interpreter/parser/Lexer.java
+++ b/watertemplate-engine/src/main/java/org/watertemplate/interpreter/parser/Lexer.java
@@ -4,6 +4,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -19,9 +21,9 @@ public class Lexer {
     private List<Terminal> previousCandidates = new ArrayList<>();
 
 
-    public List<Token> lex(final File templateFile) {
+    public List<Token> lex(final InputStream stream) {
 
-        try (final BufferedReader bufferedReader = new BufferedReader(new FileReader(templateFile))) {
+        try (final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(stream))) {
 
             List<Token> tokens = tokenize(bufferedReader);
             tokens.add(Token.END_OF_INPUT);


### PR DESCRIPTION
When using getResource it returns a URL that you then convert into a File.  If that File was actually inside a jar file then it fails to open.

````
jar:file:/folder1/folder2/project.jar!/hello.water
becomes
file:/folder1/folder2/project.jar!/hello.water
````

The solution to avoid this problem with getResource is to directly use getResourceAsStream which returns an InputStream that is easily put into lex using an InputStreamReader.

I discovered this problem when trying to use Water with SparkJava.  SparkJava allows me to compile my project as a Jar file instead of being forced to use Tomcat with War files.