### PR TITLE
Fix the incorrect license info in the POMs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
 
     <licenses>
         <license>
-            <name>GNU General Public License, Version 3</name>
-            <url>http://www.gnu.org/licenses/gpl-3.0-standalone.html</url>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
 

--- a/watertemplate-engine/pom.xml
+++ b/watertemplate-engine/pom.xml
@@ -21,8 +21,8 @@
 
     <licenses>
         <license>
-            <name>GNU General Public License, Version 3</name>
-            <url>http://www.gnu.org/licenses/gpl-3.0-standalone.html</url>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
 

--- a/watertemplate-example/pom.xml
+++ b/watertemplate-example/pom.xml
@@ -21,8 +21,8 @@
 
     <licenses>
         <license>
-            <name>GNU General Public License, Version 3</name>
-            <url>http://www.gnu.org/licenses/gpl-3.0-standalone.html</url>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
 

--- a/watertemplate-i18n-maven-plugin/pom.xml
+++ b/watertemplate-i18n-maven-plugin/pom.xml
@@ -21,8 +21,8 @@
 
     <licenses>
         <license>
-            <name>GNU General Public License, Version 3</name>
-            <url>http://www.gnu.org/licenses/gpl-3.0-standalone.html</url>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
 

--- a/watertemplate-jaxrs-binding/pom.xml
+++ b/watertemplate-jaxrs-binding/pom.xml
@@ -21,8 +21,8 @@
 
     <licenses>
         <license>
-            <name>GNU General Public License, Version 3</name>
-            <url>http://www.gnu.org/licenses/gpl-3.0-standalone.html</url>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
 


### PR DESCRIPTION
Your LICENSE.md file indicates an Apache 2.0 license.  Fixing your POMs to match.