### PR TITLE
Fix reading resources inside jars

### DIFF
--- a/watertemplate-engine/src/main/java/org/watertemplate/interpreter/WaterInterpreter.java
+++ b/watertemplate-engine/src/main/java/org/watertemplate/interpreter/WaterInterpreter.java
@@ -7,7 +7,6 @@ import org.watertemplate.interpreter.parser.Lexer;
 import org.watertemplate.interpreter.parser.Parser;
 import org.watertemplate.interpreter.parser.Token;
 
-import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Locale;
@@ -34,7 +33,7 @@ public abstract class WaterInterpreter {
     }
 
     InputStream templateFileWith(final Locale locale) {
-        final String templateFileURI = "templates" + File.separator + locale + File.separator + templateFilePath;
+        final String templateFileURI = "templates/" + locale + "/" + templateFilePath;
         InputStream stream = getClass().getClassLoader().getResourceAsStream(templateFileURI);
 
         if (stream == null && !locale.equals(defaultLocale)) {


### PR DESCRIPTION
Reading files from within jars does not work, and after a bit of digging I found the issue with the current implementation. You have to use "/", not File.seperator when loading internal jar resources.

My reasoning is from my own experimentation after it didn't work when exporting a runnable jar, and further cemented by this SO answer:
http://stackoverflow.com/a/9910404/3849816